### PR TITLE
Adding some interview questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Questions are grouped into three buckets: [General](#general), [Technical](#tech
     + What kind of elements can `title` attributes be used on?
     + What sort of information is appropriate for use with the `title` attribute?
 - Describe a scenario where you might need to use `aria-describedby`.
+- What is "tabtrapping" and when should it be used?
+- What are different use cases and values for `tabindex`?
 - What are landmark roles and how can they be useful?
 - In what situations might you use a toggle button, vs a switch control, vs a checkbox?
 - Describe methods to hide content:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Questions are grouped into three buckets: [General](#general), [Technical](#tech
     + What kind of elements can `title` attributes be used on?
     + What sort of information is appropriate for use with the `title` attribute?
 - Describe a scenario where you might need to use `aria-describedby`.
-- What is "tabtrapping" and when should it be used?
-- What are different use cases and values for `tabindex`?
+- What is a focus trap, or focus trapping? Describe an instance of when you'd need focus trapping, and how it can be an accessibility failure.
+- Describe a situation where one might need to add or modify the the focusability of an element by using the `tabindex` attribute.
 - What are landmark roles and how can they be useful?
 - In what situations might you use a toggle button, vs a switch control, vs a checkbox?
 - Describe methods to hide content:


### PR DESCRIPTION
1. Tabtrapping is used in modal windows to make sure the tab key does not bring focus to something in the background
2. `tabindex` is used for html elements that are not naturally focusable to allow them to be focused (if the `tabindex` is 0) or to remove an item from the tab order (`tabindex` of -1)